### PR TITLE
Fixes incorrect ctype

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,11 @@ on: [push, pull_request]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ test:
 	nosetests --with-coverage --cover-package=opensimplex tests/
 
 benchmark:
-	export PYTHONPATH=$PYTHONPATH:./opensimplex
-	python tests/benchmark_opensimplex.py
+	export PYTHONPATH=.; python tests/benchmark_opensimplex.py
 
 html:
 	python setup.py --long-description | rst2html.py > README.html

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,8 @@ CREDITS
 - A Svensson - Python port and package author
 - CreamyCookie - Cleanup and optimizations
 - Owen Raccuglia - Test cases
+- /u/redblobgames - Fixed conversion for Java's long type, see `Reddit <https://old.reddit.com/r/proceduralgeneration/comments/327zkm/repeated_patterns_in_opensimplex_python_port/cq8tth7/>`_
+- PetyaVasya - Found bug with using `c_long` on Windows systems, see `Issue #7 <https://github.com/lmas/opensimplex/issues/7>`_
 
 LICENSE
 ================================================================================

--- a/opensimplex/opensimplex.py
+++ b/opensimplex/opensimplex.py
@@ -2,7 +2,7 @@
 # Based on: https://gist.github.com/KdotJPG/b1270127455a94ac5d19
 
 import sys
-from ctypes import c_long
+from ctypes import c_int64
 from math import floor as _floor
 
 
@@ -78,7 +78,7 @@ GRADIENTS_4D = (
 def overflow(x):
     # Since normal python ints and longs can be quite humongous we have to use
     # this hack to make them be able to overflow
-    return c_long(x).value
+    return c_int64(x).value
 
 
 class OpenSimplex(object):


### PR DESCRIPTION
- Changed to using `c_int64` to match correct Java `long` type (bug on windows), see #7
- Running tests on more OS
- Updated credits