### PR TITLE
Faster code execution with Numba and Numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ coverage
 nose
 pycodestyle
 twine
+numba
+numpy


### PR DESCRIPTION
Hi all, I have been playing with drawing from noise using opensimplex. Sadly, is too slow if you want to compute a large picture, or a long animation.
Here I propose a patch to use the Numba jit and numpy. There are few lines changed and the improvement is very promising with a 75% speed improvement (from ~270msec to ~68msec in the benchmark below). 

Old code benchmark: 

PYTHONPATH=opensimplex/ python3 -m timeit 'from opensimplex import OpenSimplex; s=OpenSimplex(seed=0);
[s.noise2d(0.1, 0.1) for n in range(100000)]'
1 loop, best of 5: 278 msec per loop

Patched code benchmark:

PYTHONPATH=opensimplex/ python3 -m timeit 'from opensimplex import OpenSimplex; s=OpenSimplex(seed=0);
[s.noise2d(0.1, 0.1) for n in range(100000)]'
1 loop, best of 5: 68.7 msec per loop


Cheers from Chile!