### PR TITLE
Updating _noise2a and _noise4a to output multidimensional arrays

### DIFF
--- a/opensimplex/opensimplex.py
+++ b/opensimplex/opensimplex.py
@@ -118,15 +118,6 @@ def _extrapolate4(perm, xsb, ysb, zsb, wsb, dx, dy, dz, dw):
 
 @njit(cache=True, parallel=True)
 def _noise2a(x: np.ndarray, y: np.ndarray, perm: np.ndarray):
-    """
-    2D simplex noise using numpy arrays. Takes two arrays of indices and outputs the noise for
-    those indices in a 2D array
-    :param x: numpy array of x-coords
-    :param y: numpy array of y-coords
-    :param perm: generated permutation
-    :return: numpy array of shape (y.size, x.size) with the generated noise for the supplied
-    coordinates.
-    """
     noise = np.empty((y.size, x.size), dtype=np.double)
     for y_i in prange(y.size):
         for x_i in prange(x.size):
@@ -144,17 +135,6 @@ def _noise3a(x, y, z, perm, perm_grad_index3):
 
 @njit(cache=True, parallel=True)
 def _noise4a(x: np.ndarray, y: np.ndarray, z: np.ndarray, w: np.ndarray, perm: np.ndarray):
-    """
-    4D simplex noise using numpy arrays. Takes arrays of indices as input, and ouputs the 
-    generated noise in a 4D array of size(w.size, z.size, y.size, x.size)
-    :param x: numpy array of x-coords
-    :param y: numpy array of y-coords
-    :param z: numpy array of z indices
-    :param w: numpy array of w indices
-    :param perm: numpy array of generated permutation
-    :return: 4D numpy array of shape (w.size, z.size, y.size, x.size) with generated noise for 
-    supplied indices
-    """
     noise = np.empty((w.size, z.size, y.size, x.size), dtype=np.double)
     for w_i in prange(w.size):
         for z_i in prange(z.size):

--- a/opensimplex/opensimplex.py
+++ b/opensimplex/opensimplex.py
@@ -44,7 +44,17 @@ class OpenSimplex(object):
     def noise4(self, x, y, z, w):
         return _noise4(x, y, z, w, self._perm)
 
-    def noise4array(self, x, y, z, w):
+    def noise4array(self, x: np.ndarray, y: np.ndarray, z: np.ndarray, w: np.ndarray):
+        """
+        4D simplex noise using numpy arrays. Takes arrays of indices as input, and ouputs the 
+        generated noise in a 4D array of size(w.size, z.size, y.size, x.size)
+        :param x: numpy array of x-coords
+        :param y: numpy array of y-coords
+        :param z: numpy array of z indices
+        :param w: numpy array of w indices
+        :return: 4D numpy array of shape (w.size, z.size, y.size, x.size) with generated noise for 
+        supplied indices
+        """
         return _noise4a(x, y, z, w, self._perm)
 
 ################################################################################
@@ -133,10 +143,24 @@ def _noise3a(x, y, z, perm, perm_grad_index3):
 
 
 @njit(cache=True, parallel=True)
-def _noise4a(x, y, z, w, perm):
-    noise = np.zeros(x.size, dtype=np.double)
-    for i in prange(x.size):
-        noise[i] = _noise4(x[i], y[i], z[i], w[i], perm)
+def _noise4a(x: np.ndarray, y: np.ndarray, z: np.ndarray, w: np.ndarray, perm: np.ndarray):
+    """
+    4D simplex noise using numpy arrays. Takes arrays of indices as input, and ouputs the 
+    generated noise in a 4D array of size(w.size, z.size, y.size, x.size)
+    :param x: numpy array of x-coords
+    :param y: numpy array of y-coords
+    :param z: numpy array of z indices
+    :param w: numpy array of w indices
+    :param perm: numpy array of generated permutation
+    :return: 4D numpy array of shape (w.size, z.size, y.size, x.size) with generated noise for 
+    supplied indices
+    """
+    noise = np.empty((w.size, z.size, y.size, x.size), dtype=np.double)
+    for w_i in prange(w.size):
+        for z_i in prange(z.size):
+            for y_i in prange(y.size):
+                for x_i in prange(x.size):
+                    noise[w_i, z_i, y_i, x_i] = _noise4(x[x_i], y[_i], z[_i], w[_i], perm)
     return noise
 
 ################################################################################

--- a/opensimplex/opensimplex.py
+++ b/opensimplex/opensimplex.py
@@ -24,7 +24,7 @@ class OpenSimplex(object):
     def noise2(self, x, y):
         return _noise2(x, y, self._perm)
 
-    def noise2array(self, x, y):
+    def noise2array(self, x: np.ndarray, y: np.ndarray):
         return _noise2a(x, y, self._perm)
 
     def noise3(self, x, y, z):
@@ -99,10 +99,20 @@ def _extrapolate4(perm, xsb, ysb, zsb, wsb, dx, dy, dz, dw):
 
 
 @njit(cache=True, parallel=True)
-def _noise2a(x, y, perm):
-    noise = np.zeros(x.size, dtype=np.double)
-    for i in prange(x.size):
-        noise[i] = _noise2(x[i], y[i], perm)
+def _noise2a(x: np.ndarray, y: np.ndarray, perm: np.ndarray):
+    """
+    2D simplex noise using numpy arrays. Takes two arrays of indices and outputs the noise for
+    those indices in a 2D array
+    :param x: numpy array of x-coords
+    :param y: numpy array of y-coords
+    :param perm: generated permutation
+    :return: numpy array of shape (y.size, x.size) with the generated noise for the supplied
+    coordinates.
+    """
+    noise = np.empty((y.size, x.size), dtype=np.double)
+    for y_i in prange(y.size):
+        for x_i in prange(x.size):
+            noise[y_i, x_i] = _noise2(x[x_i], y[y_i], perm)
     return noise
 
 

--- a/opensimplex/opensimplex.py
+++ b/opensimplex/opensimplex.py
@@ -25,6 +25,14 @@ class OpenSimplex(object):
         return _noise2(x, y, self._perm)
 
     def noise2array(self, x: np.ndarray, y: np.ndarray):
+        """
+        2D simplex noise using numpy arrays. Takes two arrays of indices and outputs the noise for
+        those indices in a 2D array
+        :param x: numpy array of x-coords
+        :param y: numpy array of y-coords
+        :return: numpy array of shape (y.size, x.size) with the generated noise for the supplied
+        coordinates.
+        """
         return _noise2a(x, y, self._perm)
 
     def noise3(self, x, y, z):


### PR DESCRIPTION
Updating the _noise2a and _noise4a (noticed another pull request for _noise3a so have omitted in this) functions to output a multidimensional array. Given the inputs are numpy arrays of indices/coordinates then it will iterate over them, constructing a multidimensional array of the generated noise, like in the example code supplied in the repo. Have also added some docstrings and typehints in the functions.